### PR TITLE
Fix at.js 2.0 example typos, missing properties

### DIFF
--- a/help/c-implementing-target/c-implementing-target-for-client-side-web/cmp-at.js-functions.md
+++ b/help/c-implementing-target/c-implementing-target-for-client-side-web/cmp-at.js-functions.md
@@ -202,21 +202,20 @@ adobe.target.getOffers({
 
 ```
 adobe.target.getOffers({
-request: {
-"prefetch": {
-  "views": [
-    {
-      "parameters": {
-        "ad": "1"
-      },
-      "profileParameters": {
-        "age": 23
-      }
+  request: {
+    "prefetch": {
+      "views": [
+        {
+          "parameters": {
+            "ad": "1"
+          },
+          "profileParameters": {
+            "age": 23
+          }
+        }
+      ]
     }
-  ]
-}
   }
-}
 });
 ```
 
@@ -226,17 +225,22 @@ request: {
 adobe.target.getOffers({
   request: {
     execute: {
-      mboxes: [{
-        mbox: "foo"
-      },{
-        mbox: "bla",
-        parameters: {
-          a: 1
+      mboxes: [
+        {
+          index: 0,
+          name: "first-mbox"
         },
-        profileParameters: {
-          b: 2
+        {
+          index: 1,
+          name: "second-mbox",
+          parameters: {
+            a: 1
+          },
+          profileParameters: {
+            b: 2
+          }
         }
-      }]
+      ]
     }
   }
 });


### PR DESCRIPTION
Fixed a few typos in one of the code examples, cleaned up the spacing in another.