### PR TITLE
adobe.target.trackEvent does not support `type` parameter

### DIFF
--- a/help/c-implementing-target/c-implementing-target-for-client-side-web/adobe-target-trackevent.md
+++ b/help/c-implementing-target/c-implementing-target-for-client-side-web/adobe-target-trackevent.md
@@ -18,7 +18,6 @@ Here are the API details:
 |--- |--- |--- |--- |
 |mbox|String|Yes|Mbox name<br>**Note**: If a trackEvent() call is fired with an mbox name that has already fired on the page, the SDID of trackEvent() is reset and will be different than the Target calls on the page. However, firing a trackEvent() call with a different mbox name keeps the trackEvent() call's SDID consistent with the Page Load Request/triggerView() calls on the page.|
 |selector|String|No|CSS selectors used to find the HTML elements. The event listeners will be attached to found elements.|
-|type|String|No|Represents a registered event type. It can be both HTML known events like: click, mousedown ,etc., as well as custom HTML events.|
 |preventDefault|Boolean|No|Indicates whether to use `event.preventDefault()` in the event listener callback. Defaults to false.<br>**Note**: Only `form[submit] and `a[click]` are supported. Other scenarios are not supported due to complexity and huge amount of scenarios to support.|
 |params|Object|No|Mbox parameters. An object of key-value pairs that has the following structure:<br>`{ "param1": "value1", "param2": "value2"}`|
 |timeout|Number|No|Timeout in milliseconds.<br>If not specified, default value is used:<br>`...timeoutInSeconds: 0.15...}`|


### PR DESCRIPTION
This parameter is not respected and is staticly set to "display"

![image](https://user-images.githubusercontent.com/7582152/116987833-d499f780-accf-11eb-9446-0015e43e0b2a.png)
![image](https://user-images.githubusercontent.com/7582152/116987873-e4194080-accf-11eb-939f-0a478b9115e2.png)
