### PR TITLE
Correct description of not allowed characters

### DIFF
--- a/help/c-implementing-target/c-implementing-target-for-client-side-web/adobe.target.sendnotifications-atjs-21.md
+++ b/help/c-implementing-target/c-implementing-target-for-client-side-web/adobe.target.sendnotifications-atjs-21.md
@@ -51,7 +51,7 @@ This function sends a notification to Target edge when an experience is rendered
 |Request > notifications > view > key|String|No|`<=` 512 characters.|View key. The key that was set with the view via the API.|
 |Request > notifications > view > state|String|No||View state token.|
 
-**Note**: The following characters are allowed for `Request > notifications > mbox > name`:
+**Note**: The following characters are *not* allowed for `Request > notifications > mbox > name`:
 
 ```
 - '-, ./=`:;&!@#$%^&*()+|?~[]{}'


### PR DESCRIPTION
In my testing it seems like these specific characters are not allowed (mostly "/" and ":") - but the docs currently say they are supported.

This change would also somewhat align with this doc page: https://experienceleague.adobe.com/docs/target/using/activities/abtest/create/ab-set-metrics.html?lang=en#activities