### PR TITLE
Exclusions are applied to all environments

### DIFF
--- a/help/main/c-recommendations/c-products/exclusions.md
+++ b/help/main/c-recommendations/c-products/exclusions.md
@@ -21,6 +21,11 @@ Some examples of times you would use exclusions include:
 
 >[!IMPORTANT]
 >
+>Exclusion rules are applied globally to all environments.
+
+
+>[!IMPORTANT]
+>
 >Static and dynamic exclusion rules are powerful features that can help you with your marketing efforts. For detailed information, examples, and use-case scenarios, see [Use Dynamic and Static Inclusion Rules](/help/main/c-recommendations/c-algorithms/use-dynamic-and-static-inclusion-rules.md#concept_4CB5C0FA705D4E449BD0B37B3D987F9F).
 
 ## Create an exclusion


### PR DESCRIPTION
There's currently no note about the fact that one you create an exclusion, it's applied to all environments. 

There's a very ambiguous note at the bottom that says: 

"Be aware that exclusions are available across the entire account. Ensure that you consider this before deleting an exclusion. Deleted exclusions cannot be recovered." 

However, "Available" doesn't mean "applied to". The exclusions can be available to anyone to edit or see in the account, but that doesn't mean they are applied to all environments.